### PR TITLE
Enhancements: Remove duplicate events and show events calendar title.

### DIFF
--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -240,14 +240,18 @@ class CalendarServer(dbus.service.Object):
             query.max_results = 2**31-1
             feed = self.client.CalendarQuery(query)
 
+            if debug: print 'Getting events...'
             for event in feed.entry:
                 event_id = event.id.text
                 title = event.title.text
 
-                if debug: print prefix, '  ', title
+                if debug:
+                    print '%s Event: title=%s' % ( prefix, repr(title) )
 
                 for when in event.when:
-                    if debug: print prefix, '    ', when.start_time, 'to', when.end_time
+                    if debug:
+                        print '%s    start_time=%s end_time=%s' % ( prefix,
+                                repr(when.start_time), repr(when.end_time) )
 
                     allday = False
                     start, allday = self.parse_time(when.start_time)

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -12,6 +12,7 @@ import dbus.service
 import gtk
 import iso8601
 import keyring
+import calendar
 
 
 #  change to "True" to get debugging messages
@@ -25,22 +26,16 @@ def get_month_key(date, first_day_of_week=7):
      - `first_day_of_week`: integer representing first day of week used by
                             calendar; Monday -> 1, ..., Sunday -> 7
     """
-    start_date = date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    while start_date.isocalendar()[2] != first_day_of_week:
-        start_date -= timedelta(days=1)
+    month_calendar = list(calendar.Calendar(first_day_of_week - 1
+            ).itermonthdates(date.year, date.month))
 
-    end_date = date.replace(day=28, hour=23, minute=59, second=59,
-            microsecond=999999)
-    initial_month = end_date.month
-    while end_date.month == initial_month:
-        end_date += timedelta(days=1)
-    end_date -= timedelta(days=1)
-    last_day_of_week = first_day_of_week - 1 or 7
-    while end_date.isocalendar()[2] != last_day_of_week:
-        end_date += timedelta(days=1)
+    start_date = datetime(month_calendar[0].year, month_calendar[0].month,
+            month_calendar[0].day)
+    end_date = datetime(month_calendar[-1].year, month_calendar[-1].month,
+            month_calendar[-1].day, hour = 23, minute = 59, second = 59)
 
-    return int(mktime(start_date.timetuple())),\
-            int(mktime(end_date.timetuple()))
+    return ( int(mktime(start_date.timetuple())),
+            int(mktime(end_date.timetuple())) )
 
 
 class MonthEvents(object):

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -240,7 +240,6 @@ class CalendarServer(dbus.service.Object):
             query.max_results = 2**31-1
             feed = self.client.CalendarQuery(query)
 
-            if debug: print 'Getting events...'
             for event in feed.entry:
                 event_id = event.id.text
                 title = event.title.text

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -61,13 +61,7 @@ class MonthEvents(object):
         end = self.end
         if (event.start_time >= start and event.start_time < end) or\
                 (event.start_time <= start and event.end_time - 1 > start):
-            self.gnome_events.append(('',                       # uid
-                           event.title if event.title else '',  # summary
-                           '',                                  # description
-                           event.allday,                        # allDay
-                           event.start_time,                    # date
-                           event.end_time,                      # end
-                           {}))                                 # extras
+            self.gnome_events.append(event.as_gnome_event())
 
     def updated(self):
         self.last_update = datetime.now()
@@ -105,6 +99,15 @@ class Event(object):
         self.start_time = start_time
         self.end_time = end_time
         self.allday = allday
+
+    def as_gnome_event(self):
+        return ('',                                 # uid
+                self.title if self.title else '',   # summary
+                '',                                 # description
+                self.allday,                        # allDay
+                self.start_time,                    # date
+                self.end_time,                      # end
+                {})                                 # extras
 
     def __repr__(self):
         return '<Event: %r>' % (self.title)

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -278,23 +278,21 @@ class CalendarServer(dbus.service.Object):
         """Check if months around month declared by `key` need update or not
         yet fetched"""
 
-        # Check if this month needs update
-        if self.months[key].needs_update():
-            return True
+        #  get a list of months to check
+        months_to_check = [key]
+        for i in range(months_back):
+            months_to_check.append(
+                    self.months[months_to_check[-1]].get_prev_month_key())
+        months_to_check.reverse()
+        for i in range(months_ahead):
+            months_to_check.append(
+                    self.months[months_to_check[-1]].get_next_month_key())
 
-        #  walk forward and backward a number of months looking for a
-        #  month that needs updating
-        for months_to_retrieve, get_month_key in (
-                ( months_back, lambda x: self.months[x].get_prev_month_key() ),
-                ( months_ahead, lambda x: self.months[x].get_next_month_key() ),
-                ):
-            month_key = key
-            for i in range(0, months_to_retrieve):
-                month_key = get_month_key(month_key)
-                print '*******************', month_key
-                month = self.months.get(month_key, None)
-                if not month or (month and month.needs_update()):
-                    return True
+        #  Do any of those months need updating
+        for month_key in months_to_check:
+            month = self.months.get(month_key)
+            if not month or (month and month.needs_update()):
+                return True
 
         # All up to date
         return False

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -16,6 +16,7 @@ import keyring
 
 #  change to "True" to get debugging messages
 debug = False
+debug = True
 
 def get_month_key(date, first_day_of_week=7):
     """Returns range of dates displayed on calendars for `date`'s month.
@@ -257,7 +258,7 @@ class CalendarServer(dbus.service.Object):
                     end, _ = self.parse_time(when.end_time)
 
                     e = Event(event_id, title, start, end, allday)
-                    for _, month in months.items():
+                    for month in months.values():
                         month.add_event(e)
 
         # Replace old months events by new ones

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -14,6 +14,9 @@ import iso8601
 import keyring
 
 
+#  change to "True" to get debugging messages
+debug = False
+
 def get_month_key(date, first_day_of_week=7):
     """Returns range of dates displayed on calendars for `date`'s month.
     Parameters:
@@ -174,7 +177,7 @@ class CalendarServer(dbus.service.Object):
 
             if not url in urls:
                 print '  ', title
-#                print '    ', url
+                if debug: print '    ', url
                 urls.add(url)
                 calendars.append((title, url))
 
@@ -241,10 +244,10 @@ class CalendarServer(dbus.service.Object):
                 event_id = event.id.text
                 title = event.title.text
 
-#                print prefix, '  ', title
+                if debug: print prefix, '  ', title
 
                 for when in event.when:
-#                    print prefix, '    ', when.start_time, 'to', when.end_time
+                    if debug: print prefix, '    ', when.start_time, 'to', when.end_time
 
                     allday = False
                     start, allday = self.parse_time(when.start_time)

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -255,7 +255,7 @@ class CalendarServer(dbus.service.Object):
 
                     allday = False
                     start, allday = self.parse_time(when.start_time)
-                    end, _ = self.parse_time(when.end_time)
+                    end = self.parse_time(when.end_time)[0]
 
                     e = Event(event_id, title, start, end, allday)
                     for month in months.values():

--- a/test
+++ b/test
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+#  Unit tests for gnome-shell-google-calendar
+
+
+import unittest
+import datetime
+
+#  remove the copied module
+def cleanup():
+   import os
+   os.remove('gsgc_test.py')
+   if os.path.exists('gsgc_test.pyc'):
+      os.remove('gsgc_test.pyc')
+import atexit
+atexit.register(cleanup)
+
+#  import, but have to use a python-compatible name
+import shutil
+shutil.copy('gnome-shell-google-calendar.py', 'gsgc_test.py')
+import gsgc_test as gsgc
+
+
+#################################################
+class TestGnomeGoogleCalendar(unittest.TestCase):
+   def test_GetMonthKey(self):
+      from time import strftime, localtime
+
+      def tostr(x):
+         return [ strftime('%Y%m%d %H%M%S', localtime(x)) for x in x ]
+
+      self.assertEqual(tostr(
+            gsgc.get_month_key(datetime.datetime(2011, 12, 12))),
+            ['20111127 000000', '20111231 235959'])
+      self.assertEqual(tostr(
+            gsgc.get_month_key(datetime.datetime(2011, 11, 1))),
+            ['20111030 000000', '20111203 235959'])
+      self.assertEqual(tostr(
+            gsgc.get_month_key(datetime.datetime(2011, 1, 31))),
+            ['20101226 000000', '20110205 235959'])
+      self.assertEqual(tostr(
+            gsgc.get_month_key(datetime.datetime(2012, 1, 31))),
+            ['20120101 000000', '20120204 235959'])
+
+suite = unittest.TestLoader().loadTestsFromTestCase(TestGnomeGoogleCalendar)
+unittest.TextTestRunner(verbosity = 2).run(suite)


### PR DESCRIPTION
I've updated this pull request to include a bunch of changes I've made.  The ultimate goal is to deal with lots of shared calendars better.  When I first pulled up the calendar after running gnome-shell-google-calendar, it took up most of the height on my 30" monitor, because of several events that my whole company is attending, and I am subscribed to everyone's calendars.

Here is an overview of the major changes:
- Only show one event for multiple events with the same title and start date.
- Show which calendar(s) the event is coming from.

Then there are a number of changes that I made as I was wrapping my head around what was happening in this code, to simplify things:
- Make it so that you can enable/disable debugging prints via a global "debug" flag rather than commenting out lines.
- Getting rid of some superfluous "_" variables and backslashes.
- Adding some test code, largely so I could refactor get_month_key without breaking it.
- Refactoring get_month_key() and need_update_near() to be more obvious.  The latter I re-factored once and then re-factored again, hence the two commits.
- Months now store the full event, and events store the calendar title (moving towards the deduplication and calendar display features).
