### PR TITLE
Added support for Gnome Online Accounts

### DIFF
--- a/README
+++ b/README
@@ -24,8 +24,8 @@
       
         ./gnome-shell-google-calendar.py
       
-      You will be prompted for your Google Calendar email and password the
-      first time, which will be stored safely in your keyring.
+      You will be prompted for your Google Calendar email the
+      first time. A password is not neccesary, as gnome-online-accounts is used.
       
       Once logged in, events from all your calendars should appear in
       GNOME Shell's calendar.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,26 @@
+'''
+Created on 17.02.2012
+
+@author: flocki
+'''
+import json
+
+def set(parameter, value):
+    config = get(None)
+    config[parameter] = value
+    with open('config.json', 'w') as fp:
+        json.dump(config, fp)
+
+def get(parameter):
+    try:
+        with open('config.json', 'r') as fp:
+            config = json.load(fp)
+    except:
+        config = dict()
+
+    if parameter is None:
+        return config
+    if config.has_key(parameter):
+        return config.get(parameter)
+    else:
+        config[parameter] = None

--- a/oauth.py
+++ b/oauth.py
@@ -1,0 +1,55 @@
+'''
+Created on 17.02.2012
+
+@author: flocki
+'''
+import dbus
+#import dbus.mainloop.glib
+#import dbus.service
+import gdata.calendar.client
+
+
+def oauth_prompt():
+    bus = dbus.SessionBus()
+    #accounts = bus.get_object('org.gnome.OnlineAccounts', '/org/gnome/OnlineAccounts/Accounts')
+    online_accounts = bus.get_object('org.gnome.OnlineAccounts', '/org/gnome/OnlineAccounts')
+
+    l = online_accounts.GetManagedObjects(dbus_interface='org.freedesktop.DBus.ObjectManager')
+
+    accounts = []
+    for account_info in l.values():
+        #print account_info
+        if account_info.has_key('org.gnome.OnlineAccounts.Account'):
+            email = str(account_info['org.gnome.OnlineAccounts.Account']['PresentationIdentity'])
+            print "%d. %s" % (len(accounts), email)
+            accounts.append(email)
+    email = accounts[ int(raw_input('Please choose the Account: ')) ]
+    print "You choose '{0}'".format(email)
+    return email
+
+def oauth_login(email):
+    bus = dbus.SessionBus()
+    online_accounts = bus.get_object('org.gnome.OnlineAccounts', '/org/gnome/OnlineAccounts')
+
+    l = online_accounts.GetManagedObjects(dbus_interface='org.freedesktop.DBus.ObjectManager')
+
+    for account_path, account_info in l.items():
+        #print account_path
+        #print account_info
+        if account_info.has_key('org.gnome.OnlineAccounts.Account') and str(account_info['org.gnome.OnlineAccounts.Account']['PresentationIdentity']) == email:
+            consumer_key = str(account_info['org.gnome.OnlineAccounts.OAuthBased']['ConsumerKey'])
+            consumer_secret = str(account_info['org.gnome.OnlineAccounts.OAuthBased']['ConsumerSecret'])
+
+            o = bus.get_object('org.gnome.OnlineAccounts', account_path)
+
+            oauth_data = o.get_dbus_method('GetAccessToken', 'org.gnome.OnlineAccounts.OAuthBased')()
+
+            access_token = str(oauth_data[0])
+            access_token_secret = str(oauth_data[1])
+
+            client = gdata.calendar.client.CalendarClient(source='gnome-shell-google-calendar')
+            client.auth_token = gdata.gauth.OAuthHmacToken(consumer_key, consumer_secret, access_token, access_token_secret, gdata.gauth.ACCESS_TOKEN)
+            return client
+
+    raise Exception
+


### PR DESCRIPTION
Instead of prompting for email and password use the Gnome Online Accounts introduced with gnome3. Additionally the account-email is stored in a json file.
