### PR TITLE
Use overridename if available

### DIFF
--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -241,17 +241,17 @@ class CalendarServer(dbus.service.Object):
     def get_excludes(self, filename):
         '''Gets a list of calendars to exclude'''
         with open(filename, 'r') as fp:
-            return [line.strip() for line in fp]
+            return frozenset(line.strip() for line in fp)
 
     def get_calendars(self):
         feed = self.client.GetAllCalendarsFeed()
 
         # Load excluded calendars from excludes file
-        excludes = []
+        excludes = set()
         for filename in ('excludes',
                 os.path.expanduser('~/.gnome-shell-google-calendar-excludes')):
             if os.path.exists(filename):
-                excludes += self.get_excludes(filename)
+                excludes |= self.get_excludes(filename)
 
         calendars = []
         urls = set()

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -259,7 +259,10 @@ class CalendarServer(dbus.service.Object):
         print feed.title.text + ':'
 
         for calendar in feed.entry:
-            title = calendar.title.text
+            if calendar.overridename:
+                title = calendar.overridename.value
+            else:
+                title = calendar.title.text
             url = calendar.content.src
 
             if title in excludes:


### PR DESCRIPTION
The first commit uses overridename as the title if it's available.
This makes it possible to exclude other people's calendars who share the same name as one of your own calendars without having to rename your own calendar (but instead renaming theirs).

The second commit is just a minor speed up as checking a set is constant time (vs checking a list which is linear).
