### PR TITLE
Fixes #23 and hopefully fixes #21.

### DIFF
--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -245,7 +245,15 @@ class CalendarServer(dbus.service.Object):
             return frozenset(line.strip() for line in fp)
 
     def get_calendars(self):
-        feed = self.client.GetAllCalendarsFeed()
+        while True:
+            try:
+                feed = self.client.GetAllCalendarsFeed()
+                break
+            except Exception, e:
+                print '*** Exception:', e
+                print 'Error retrieving all calendars.  Trying again in 5 seconds...'
+                sleep(5)
+                continue
 
         # Load excluded calendars from excludes file
         excludes = set()


### PR DESCRIPTION
Tries to retrieve all calendars.  Upon success, continues.  Upon
failure, prints the exception and tries again in 5 seconds, until
forever.

I verified this fixes #23, but I cannot verify this fixes #21, since it
seems random.

```
Logging in as '???@???.com'...
*** Exception: [Errno -2] Name or service not known
Error retrieving all calendars.  Trying again in 5 seconds...

...

*** Exception: Too many redirects from server: 302, <HTML>
<HEAD>
<TITLE>Moved Temporarily</TITLE>
</HEAD>
<BODY BGCOLOR="#FFFFFF" TEXT="#000000">
<H1>Moved Temporarily</H1>
The document has moved <A HREF="https://www.google.com/calendar/feeds/default/allcalendars/full?gsessionid=???">here</A>.
</BODY>
</HTML>

Error retrieving all calendars.  Trying again in 5 seconds...
```
