### PR TITLE
Fixes #31.

### DIFF
--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -461,11 +461,18 @@ if __name__ == '__main__':
     # Login
     client = None
     while not client:
+        print "Logging in as '%s'..." % account
         try:
-            print "Logging in as '%s'..." % account
             client = oauth.oauth_login(account)
         except Exception as e:
-            account = oauth.oauth_prompt()
+            print "Error logging in as '%s'" % account
+            print "'%s' may not be a GNOME online account.  A list of existing accounts is below." % account
+            print 'If you do not see a list of accounts, then you first need to add one.'
+            print 'For more information, see http://library.gnome.org/users/gnome-help/stable/accounts.html'
+            try:
+                account = oauth.oauth_prompt()
+            except ValueError, e:
+                print 'You have entered an invalid account number.  Please enter an integer.'
             config.set('account', account)
 
     myserver = CalendarServer(client)

--- a/gnome-shell-google-calendar.py
+++ b/gnome-shell-google-calendar.py
@@ -41,7 +41,7 @@ def write_traceback(f):
             if debug:
                 print 'Returning from %s: %s' % (f, ret)
             return ret
-        except Exception, e:
+        except Exception as e:
             import traceback
             print '*** Exception:', e
             traceback.print_exc()
@@ -249,7 +249,7 @@ class CalendarServer(dbus.service.Object):
             try:
                 feed = self.client.GetAllCalendarsFeed()
                 break
-            except Exception, e:
+            except Exception as e:
                 print '*** Exception:', e
                 print 'Error retrieving all calendars.  Trying again in 5 seconds...'
                 sleep(5)
@@ -471,7 +471,7 @@ if __name__ == '__main__':
             print 'For more information, see http://library.gnome.org/users/gnome-help/stable/accounts.html'
             try:
                 account = oauth.oauth_prompt()
-            except ValueError, e:
+            except ValueError as e:
                 print 'You have entered an invalid account number.  Please enter an integer.'
             config.set('account', account)
 


### PR DESCRIPTION
Provides more information to the user if there is an error logging or if an invalid account number is entered.

```
$ ./gnome-shell-google-calendar.py --account anon@anon.com
Logging in as 'anon@anon.com'...
Error logging in as 'anon@anon.com'
'anon@anon.com' may not be a GNOME online account.  A list of existing accounts is below.
If you do not see a list of accounts, then you first need to add one.
For more information, see http://library.gnome.org/users/gnome-help/stable/accounts.html
0. anon1@gmail.com
1. anon2@gmail.com
Please choose the Account: anon1@gmail.com
You have entered an invalid account number.  Please enter an integer.
Logging in as 'anon@anon.com'...
Error logging in as 'anon@anon.com'
'anon@anon.com' may not be a GNOME online account.  A list of existing accounts is below.
If you do not see a list of accounts, then you first need to add one.
For more information, see http://library.gnome.org/users/gnome-help/stable/accounts.html
0. anon1@gmail.com
1. anon2@gmail.com
Please choose the Account: 0
You choose 'anon1@gmail.com'
Logging in as 'anon1@gmail.com'...
anon1@gmail.com's Calendar List:
```
